### PR TITLE
create default dirs before fixing permissions

### DIFF
--- a/7/rootfs/usr/local/bin/bitnami-pkg
+++ b/7/rootfs/usr/local/bin/bitnami-pkg
@@ -174,6 +174,7 @@ fi
 
 if [ "$BITNAMI_PKG_CHMOD" ]; then
   DIRS="/.nami /bitnami $BITNAMI_PKG_EXTRA_DIRS"
+  mkdir -p $DIRS
   if ! [[ $PACKAGE_NAME =~ .*-client ]]; then
     mkdir -p /bitnami/$PACKAGE_NAME
   fi


### PR DESCRIPTION
The current code is based on a wrong assumption: There are additional modules that do not match `-client` so at least one will create the `/bitnami` directories or other directories passed via env var.