### PR TITLE
Fix syntax typo

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -39,7 +39,7 @@ RUN cd /tmp && \
     tar xzf nami-$NAMI_VERSION-linux-x64.tar.gz --strip 1 -C /opt/bitnami/nami && \
     rm nami-$NAMI_VERSION-linux-x64.tar.gz
 
-ENV GPG_KEY_SERVERS_LIST ha.pool.sks-keyservers.net \
+ENV GPG_KEY_SERVERS_LIST=ha.pool.sks-keyservers.net \
                          hkp://p80.pool.sks-keyservers.net:80 \
                          keyserver.ubuntu.com \
                          hkp://keyserver.ubuntu.com:80 \


### PR DESCRIPTION
Trying to solve
```
Cloning "https://github.com/bitnami/redhat-extras" ...
	Commit:	82f5fb70f02f8048c0f4408b73a99db60570133a (Update redhat-extras base image)
	Author:	bitnami-bot <containers-bot@bitnami.com>
	Date:	Tue Jan 22 11:55:55 2019 +0000
error: build error: Syntax error - can't find = in "hkp://p80.pool.sks-keyservers.net:80". Must be of the form: name=value
```