### PR TITLE
Make yum install fail when trying to install missing packages

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -72,6 +72,6 @@ RUN cd /tmp && \
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=7-r260
+ENV BITNAMI_IMAGE_VERSION=7-r261
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/7/rootfs/usr/local/bin/install_packages
+++ b/7/rootfs/usr/local/bin/install_packages
@@ -1,6 +1,9 @@
 #!/bin/sh
-set -e
-set -u
+set -eu
+
+# Avoid yum ignoring missing packages
+alias yum="yum --setopt=skip_missing_names_on_install=False"
+
 n=0
 max=2
 until [ $n -gt $max ]; do


### PR DESCRIPTION
When running `yum install` with a list of packages, the default behavior when some packages exist but others don't is to show a warning and continue, ending up with an exit code 0. This is particularly bad for containers, where we want to detect this at build time as soon as this is detected.

Enabling this `yum` option the following error is shown instead:

```Error: Not tolerating missing names on install, stopping.```
